### PR TITLE
Chore: add .babelrc file to match documentation

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,13 @@
+{
+    "presets": [
+      [
+        "@babel/preset-env",
+        {
+          "targets": {
+            "node": "current"
+          }
+        }
+      ],
+      "@babel/preset-react"
+    ]
+  }


### PR DESCRIPTION
With this pr the code base is updated to include a `.babelrc` file so that it matches the current documentation [here](https://www.learnstorybook.com/intro-to-storybook/react/en/creating-addons/). 

And beforehand sorry for breaking this into smaller prs, but it looked like the way to go so that we have a more clearer way to present to the reader commit wise.

Feel free to provide feedback